### PR TITLE
Use full BSD-3-Clause SPDX specifier.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="shupeixuan@qq.com">shupeixuan</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>


### PR DESCRIPTION
Although not required, it is recommended to use the SPDX identifier in your package.xml license tag. Especially with the BSD licenses where it helps to accurately distinguish between the different variations.